### PR TITLE
添加对中文版4.1.1版本新增ASTC相关纹理的编码解码

### DIFF
--- a/src/Images/PtxDds/PtxDdsCoder.cs
+++ b/src/Images/PtxDds/PtxDdsCoder.cs
@@ -3,6 +3,7 @@ using LibWindPop.Utils.FileSystem;
 using LibWindPop.Utils.Graphics.Bitmap;
 using LibWindPop.Utils.Graphics.FormatProvider;
 using LibWindPop.Utils.Graphics.FormatProvider.Dds;
+using LibWindPop.Utils.Graphics.Texture.IGraphicsAPITexture.DirectX;
 using LibWindPop.Utils.Logger;
 using System;
 using System.IO;
@@ -43,13 +44,21 @@ namespace LibWindPop.Images.PtxDds
                 PtxDdsPixelFormat.R8_G8_B8_A8_UByte => DdsEncodingFormat.R8_G8_B8_A8_UByte,
                 PtxDdsPixelFormat.R8_G8_B8_X8_UByte => DdsEncodingFormat.R8_G8_B8_X8_UByte,
                 PtxDdsPixelFormat.R8_G8_B8_UByte => DdsEncodingFormat.R8_G8_B8_UByte,
+                PtxDdsPixelFormat.RGBA_ASTC_4x4_UByte => DdsEncodingFormat.RGBA_ASTC_4x4_UByte,
+                PtxDdsPixelFormat.RGBA_ASTC_5x5_UByte => DdsEncodingFormat.RGBA_ASTC_5x5_UByte,
+                PtxDdsPixelFormat.RGBA_ASTC_6x6_UByte => DdsEncodingFormat.RGBA_ASTC_6x6_UByte,
+                PtxDdsPixelFormat.RGBA_ASTC_8x8_UByte => DdsEncodingFormat.RGBA_ASTC_8x8_UByte,
                 _ => DdsEncodingFormat.RGBA_BC3_UByte
             };
+            bool useDx10Header = ddsFormat == DdsEncodingFormat.RGBA_ASTC_4x4_UByte
+                || ddsFormat == DdsEncodingFormat.RGBA_ASTC_5x5_UByte
+                || ddsFormat == DdsEncodingFormat.RGBA_ASTC_6x6_UByte
+                || ddsFormat == DdsEncodingFormat.RGBA_ASTC_8x8_UByte;
             using (NativeBitmap bitmap = new NativeBitmap(width, height))
             {
                 RefBitmap refBitmap = bitmap.AsRefBitmap();
                 ImageCoder.DecodeImage(pngStream, refBitmap, imageFormat);
-                DdsEncoder.EncodeDds(ptxStream, refBitmap, new DdsEncoderArgument { UseDX10Header = false, Format = ddsFormat });
+                DdsEncoder.EncodeDds(ptxStream, refBitmap, new DdsEncoderArgument { UseDX10Header = useDx10Header, Format = ddsFormat });
             }
         }
 
@@ -87,7 +96,40 @@ namespace LibWindPop.Images.PtxDds
             {
                 if ((header.ddspf.dwFlags & DDS_PIXELFORMAT.DDPF_FOURCC) != 0u)
                 {
-                    if (header.ddspf.dwFourCC == DDS_PIXELFORMAT.DXT1)
+                    if (header.ddspf.dwFourCC == DDS_PIXELFORMAT.DX10)
+                    {
+                        DDS_HEADER_DXT10 dx10Header;
+                        long headerDx10Pos = pos + 4 + sizeof(DDS_HEADER);
+                        long currentPos = ptxStream.Position;
+                        ptxStream.Seek(headerDx10Pos, SeekOrigin.Begin);
+                        ptxStream.Read(&dx10Header, (uint)sizeof(DDS_HEADER_DXT10));
+                        ptxStream.Seek(currentPos, SeekOrigin.Begin);
+                        if (dx10Header.dxgiFormat == DXGI_FORMAT.DXGI_FORMAT_ASTC_4X4_TYPELESS
+                            || dx10Header.dxgiFormat == DXGI_FORMAT.DXGI_FORMAT_ASTC_4X4_UNORM
+                            || dx10Header.dxgiFormat == DXGI_FORMAT.DXGI_FORMAT_ASTC_4X4_UNORM_SRGB)
+                        {
+                            format = PtxDdsPixelFormat.RGBA_ASTC_4x4_UByte;
+                        }
+                        else if (dx10Header.dxgiFormat == DXGI_FORMAT.DXGI_FORMAT_ASTC_5X5_TYPELESS
+                            || dx10Header.dxgiFormat == DXGI_FORMAT.DXGI_FORMAT_ASTC_5X5_UNORM
+                            || dx10Header.dxgiFormat == DXGI_FORMAT.DXGI_FORMAT_ASTC_5X5_UNORM_SRGB)
+                        {
+                            format = PtxDdsPixelFormat.RGBA_ASTC_5x5_UByte;
+                        }
+                        else if (dx10Header.dxgiFormat == DXGI_FORMAT.DXGI_FORMAT_ASTC_6X6_TYPELESS
+                            || dx10Header.dxgiFormat == DXGI_FORMAT.DXGI_FORMAT_ASTC_6X6_UNORM
+                            || dx10Header.dxgiFormat == DXGI_FORMAT.DXGI_FORMAT_ASTC_6X6_UNORM_SRGB)
+                        {
+                            format = PtxDdsPixelFormat.RGBA_ASTC_6x6_UByte;
+                        }
+                        else if (dx10Header.dxgiFormat == DXGI_FORMAT.DXGI_FORMAT_ASTC_8X8_TYPELESS
+                            || dx10Header.dxgiFormat == DXGI_FORMAT.DXGI_FORMAT_ASTC_8X8_UNORM
+                            || dx10Header.dxgiFormat == DXGI_FORMAT.DXGI_FORMAT_ASTC_8X8_UNORM_SRGB)
+                        {
+                            format = PtxDdsPixelFormat.RGBA_ASTC_8x8_UByte;
+                        }
+                    }
+                    else if (header.ddspf.dwFourCC == DDS_PIXELFORMAT.DXT1)
                     {
                         format = PtxDdsPixelFormat.RGBA_BC1_UByte;
                     }

--- a/src/Images/PtxDds/PtxDdsPixelFormat.cs
+++ b/src/Images/PtxDds/PtxDdsPixelFormat.cs
@@ -15,5 +15,9 @@
         B8_G8_R8_A8_UByte,
         B8_G8_R8_X8_UByte,
         B8_G8_R8_UByte,
+        RGBA_ASTC_4x4_UByte,
+        RGBA_ASTC_5x5_UByte,
+        RGBA_ASTC_6x6_UByte,
+        RGBA_ASTC_8x8_UByte,
     }
 }

--- a/src/Images/PtxRsb/Handler/PtxHandlerPVZ2CNAndroidV6.cs
+++ b/src/Images/PtxRsb/Handler/PtxHandlerPVZ2CNAndroidV6.cs
@@ -1,0 +1,180 @@
+using LibWindPop.Images.PtxRsb.AlphaCoder;
+using LibWindPop.Utils;
+using LibWindPop.Utils.Graphics.Bitmap;
+using LibWindPop.Utils.Graphics.Texture;
+using LibWindPop.Utils.Graphics.Texture.Coder;
+using LibWindPop.Utils.Logger;
+using System;
+using A8_UByte = LibWindPop.Images.PtxRsb.AlphaCoder.A8_UByte;
+
+namespace LibWindPop.Images.PtxRsb.Handler
+{
+    /// <summary>
+    /// 植物大战僵尸2高清版 v6 （安卓v4.1.1版本后）
+    /// </summary>
+    public sealed class PtxHandlerPVZ2CNAndroidV6 : IPtxRsbHandler
+    {
+        private readonly PtxHandlerPVZ2CNAndroidV5 m_v5 = new PtxHandlerPVZ2CNAndroidV5();
+
+        public bool UseExtend1AsAlphaSize => m_v5.UseExtend1AsAlphaSize;
+
+        public uint GetPtxSize(uint width, uint height, uint pitch, uint format, uint alphaSize)
+        {
+            if (format is >= 160u and <= 163u)
+            {
+                return GetPtxSizeWithoutAlpha(width, height, pitch, format);
+            }
+            return m_v5.GetPtxSize(width, height, pitch, format, alphaSize);
+        }
+
+        public uint GetPtxSizeWithoutAlpha(uint width, uint height, uint pitch, uint format)
+        {
+            switch (format)
+            {
+                case 160u:
+                    if (PtxRsbHandlerManager.FIX_COMPRESSED_TEX_SIZE)
+                    {
+                        if ((width & 0x3u) != 0u)
+                        {
+                            width |= 0x3u;
+                            width++;
+                        }
+                        if ((height & 0x3u) != 0u)
+                        {
+                            height |= 0x3u;
+                            height++;
+                        }
+                    }
+                    return width * height;
+                case 161u:
+                    if (PtxRsbHandlerManager.FIX_COMPRESSED_TEX_SIZE)
+                    {
+                        if ((width % 5u) != 0u)
+                        {
+                            width = ((width / 5u) + 1u) * 5u;
+                        }
+                        if ((height % 5u) != 0u)
+                        {
+                            height = ((height / 5u) + 1u) * 5u;
+                        }
+                    }
+                    return (width / 5u) * (height / 5u) * 16u;
+                case 162u:
+                    if (PtxRsbHandlerManager.FIX_COMPRESSED_TEX_SIZE)
+                    {
+                        if ((width % 6u) != 0u)
+                        {
+                            width = ((width / 6u) + 1u) * 6u;
+                        }
+                        if ((height % 6u) != 0u)
+                        {
+                            height = ((height / 6u) + 1u) * 6u;
+                        }
+                    }
+                    return (width / 6u) * (height / 6u) * 16u;
+                case 163u:
+                    if (PtxRsbHandlerManager.FIX_COMPRESSED_TEX_SIZE)
+                    {
+                        if ((width & 0x7u) != 0u)
+                        {
+                            width |= 0x7u;
+                            width++;
+                        }
+                        if ((height & 0x7u) != 0u)
+                        {
+                            height |= 0x7u;
+                            height++;
+                        }
+                    }
+                    return (width * height) >> 2;
+                default:
+                    return m_v5.GetPtxSizeWithoutAlpha(width, height, pitch, format);
+            }
+        }
+
+        public void DecodePtx(ReadOnlySpan<byte> ptxData, RefBitmap dstBitmap, uint width, uint height, uint pitch, uint format, uint alphaSize, ILogger logger)
+        {
+            switch (format)
+            {
+                case 160u:
+                    logger.Log($"{nameof(PtxHandlerPVZ2CNAndroidV6)}.{nameof(DecodePtx)} use format {nameof(RGBA_ASTC_4x4_UByte)}");
+                    TextureCoder.Decode<RGBA_ASTC_4x4_UByte>(ptxData, (int)width, (int)height, dstBitmap);
+                    break;
+                case 161u:
+                    logger.Log($"{nameof(PtxHandlerPVZ2CNAndroidV6)}.{nameof(DecodePtx)} use format {nameof(RGBA_ASTC_5x5_UByte)}");
+                    TextureCoder.Decode<RGBA_ASTC_5x5_UByte>(ptxData, (int)width, (int)height, dstBitmap);
+                    break;
+                case 162u:
+                    logger.Log($"{nameof(PtxHandlerPVZ2CNAndroidV6)}.{nameof(DecodePtx)} use format {nameof(RGBA_ASTC_6x6_UByte)}");
+                    TextureCoder.Decode<RGBA_ASTC_6x6_UByte>(ptxData, (int)width, (int)height, dstBitmap);
+                    break;
+                case 163u:
+                    logger.Log($"{nameof(PtxHandlerPVZ2CNAndroidV6)}.{nameof(DecodePtx)} use format {nameof(RGBA_ASTC_8x8_UByte)}");
+                    TextureCoder.Decode<RGBA_ASTC_8x8_UByte>(ptxData, (int)width, (int)height, dstBitmap);
+                    break;
+                default:
+                    m_v5.DecodePtx(ptxData, dstBitmap, width, height, pitch, format, alphaSize, logger);
+                    break;
+            }
+        }
+
+        public void EncodePtx(RefBitmap srcBitmap, Span<byte> ptxData, uint width, uint height, uint pitch, uint format, uint alphaSize, ILogger logger)
+        {
+            switch (format)
+            {
+                case 160u:
+                    logger.Log($"{nameof(PtxHandlerPVZ2CNAndroidV6)}.{nameof(EncodePtx)} use format {nameof(RGBA_ASTC_4x4_UByte)}");
+                    TextureCoder.Encode<RGBA_ASTC_4x4_UByte>(srcBitmap, ptxData, (int)width, (int)height);
+                    break;
+                case 161u:
+                    logger.Log($"{nameof(PtxHandlerPVZ2CNAndroidV6)}.{nameof(EncodePtx)} use format {nameof(RGBA_ASTC_5x5_UByte)}");
+                    TextureCoder.Encode<RGBA_ASTC_5x5_UByte>(srcBitmap, ptxData, (int)width, (int)height);
+                    break;
+                case 162u:
+                    logger.Log($"{nameof(PtxHandlerPVZ2CNAndroidV6)}.{nameof(EncodePtx)} use format {nameof(RGBA_ASTC_6x6_UByte)}");
+                    TextureCoder.Encode<RGBA_ASTC_6x6_UByte>(srcBitmap, ptxData, (int)width, (int)height);
+                    break;
+                case 163u:
+                    logger.Log($"{nameof(PtxHandlerPVZ2CNAndroidV6)}.{nameof(EncodePtx)} use format {nameof(RGBA_ASTC_8x8_UByte)}");
+                    TextureCoder.Encode<RGBA_ASTC_8x8_UByte>(srcBitmap, ptxData, (int)width, (int)height);
+                    break;
+                default:
+                    m_v5.EncodePtx(srcBitmap, ptxData, width, height, pitch, format, alphaSize, logger);
+                    break;
+            }
+        }
+
+        public bool PeekEncodedPtxInfo(RefBitmap srcBitmap, uint format, out uint width, out uint height, out uint pitch, out uint alphaSize)
+        {
+            switch (format)
+            {
+                case 160u:
+                    width = (uint)srcBitmap.Width;
+                    height = (uint)srcBitmap.Height;
+                    pitch = width; // bpp = 1.0
+                    alphaSize = 0u;
+                    return true;
+                case 161u:
+                    width = (uint)srcBitmap.Width;
+                    height = (uint)srcBitmap.Height;
+                    pitch = width * 16u / 25u; // bpp = 16/25 ≈ 0.64
+                    alphaSize = 0u;
+                    return true;
+                case 162u:
+                    width = (uint)srcBitmap.Width;
+                    height = (uint)srcBitmap.Height;
+                    pitch = width * 4u / 9u; // bpp = 4/9 ≈ 0.44
+                    alphaSize = 0u;
+                    return true;
+                case 163u:
+                    width = (uint)srcBitmap.Width;
+                    height = (uint)srcBitmap.Height;
+                    pitch = width >> 2; // bpp = 0.25
+                    alphaSize = 0u;
+                    return true;
+                default:
+                    return m_v5.PeekEncodedPtxInfo(srcBitmap, format, out width, out height, out pitch, out alphaSize);
+            }
+        }
+    }
+}

--- a/src/Images/PtxRsb/PtxRsbHandlerManager.cs
+++ b/src/Images/PtxRsb/PtxRsbHandlerManager.cs
@@ -29,6 +29,7 @@ namespace LibWindPop.Images.PtxRsb
             { nameof(PtxHandlerPVZ2CNAndroidV3), new PtxHandlerPVZ2CNAndroidV3() },
             { nameof(PtxHandlerPVZ2CNAndroidV4), new PtxHandlerPVZ2CNAndroidV4() },
             { nameof(PtxHandlerPVZ2CNAndroidV5), new PtxHandlerPVZ2CNAndroidV5() },
+            { nameof(PtxHandlerPVZ2CNAndroidV6), new PtxHandlerPVZ2CNAndroidV6() },
             { nameof(PtxHandlerPVZ2CNiOSV1), new PtxHandlerPVZ2CNiOSV1() },
             { nameof(PtxHandlerPVZ2CNiOSV2), new PtxHandlerPVZ2CNiOSV2() },
         };

--- a/src/Packs/Pak/ContentPipeline/PakPtxDdsAutoEncoder.cs
+++ b/src/Packs/Pak/ContentPipeline/PakPtxDdsAutoEncoder.cs
@@ -28,6 +28,10 @@ namespace LibWindPop.Packs.Pak.ContentPipeline
                 nameof(PtxDdsPixelFormat.B8_G8_R8_A8_UByte) => PtxDdsPixelFormat.B8_G8_R8_A8_UByte,
                 nameof(PtxDdsPixelFormat.B8_G8_R8_X8_UByte) => PtxDdsPixelFormat.B8_G8_R8_X8_UByte,
                 nameof(PtxDdsPixelFormat.B8_G8_R8_UByte) => PtxDdsPixelFormat.B8_G8_R8_UByte,
+                nameof(PtxDdsPixelFormat.RGBA_ASTC_4x4_UByte) => PtxDdsPixelFormat.RGBA_ASTC_4x4_UByte,
+                nameof(PtxDdsPixelFormat.RGBA_ASTC_5x5_UByte) => PtxDdsPixelFormat.RGBA_ASTC_5x5_UByte,
+                nameof(PtxDdsPixelFormat.RGBA_ASTC_6x6_UByte) => PtxDdsPixelFormat.RGBA_ASTC_6x6_UByte,
+                nameof(PtxDdsPixelFormat.RGBA_ASTC_8x8_UByte) => PtxDdsPixelFormat.RGBA_ASTC_8x8_UByte,
                 _ => PtxDdsPixelFormat.RGBA_BC3_UByte
             };
         }

--- a/src/Utils/Graphics/FormatProvider/Dds/DdsEncoder.cs
+++ b/src/Utils/Graphics/FormatProvider/Dds/DdsEncoder.cs
@@ -176,6 +176,50 @@ namespace LibWindPop.Utils.Graphics.FormatProvider.Dds
                             headerDx10.miscFlags2 = DDS_HEADER_DXT10.DDS_ALPHA_MODE_STRAIGHT;
                             coder = new RGBA_BC3_UByte();
                         }
+                        else if (ddsArgs.Format == DdsEncodingFormat.RGBA_ASTC_4x4_UByte)
+                        {
+                            header.dwFlags |= DDS_HEADER.DDSD_LINEARSIZE;
+                            header.dwPitchOrLinearSize = GetAlignSize(bitmap);
+                            headerDx10.dxgiFormat = DXGI_FORMAT.DXGI_FORMAT_ASTC_4X4_UNORM;
+                            headerDx10.resourceDimension = D3D10_RESOURCE_DIMENSION.D3D10_RESOURCE_DIMENSION_TEXTURE2D;
+                            headerDx10.miscFlag = 0u;
+                            headerDx10.arraySize = 1u;
+                            headerDx10.miscFlags2 = DDS_HEADER_DXT10.DDS_ALPHA_MODE_STRAIGHT;
+                            coder = new RGBA_ASTC_4x4_UByte();
+                        }
+                        else if (ddsArgs.Format == DdsEncodingFormat.RGBA_ASTC_5x5_UByte)
+                        {
+                            header.dwFlags |= DDS_HEADER.DDSD_LINEARSIZE;
+                            header.dwPitchOrLinearSize = GetAlignSize(bitmap);
+                            headerDx10.dxgiFormat = DXGI_FORMAT.DXGI_FORMAT_ASTC_5X5_UNORM;
+                            headerDx10.resourceDimension = D3D10_RESOURCE_DIMENSION.D3D10_RESOURCE_DIMENSION_TEXTURE2D;
+                            headerDx10.miscFlag = 0u;
+                            headerDx10.arraySize = 1u;
+                            headerDx10.miscFlags2 = DDS_HEADER_DXT10.DDS_ALPHA_MODE_STRAIGHT;
+                            coder = new RGBA_ASTC_5x5_UByte();
+                        }
+                        else if (ddsArgs.Format == DdsEncodingFormat.RGBA_ASTC_6x6_UByte)
+                        {
+                            header.dwFlags |= DDS_HEADER.DDSD_LINEARSIZE;
+                            header.dwPitchOrLinearSize = GetAlignSize(bitmap);
+                            headerDx10.dxgiFormat = DXGI_FORMAT.DXGI_FORMAT_ASTC_6X6_UNORM;
+                            headerDx10.resourceDimension = D3D10_RESOURCE_DIMENSION.D3D10_RESOURCE_DIMENSION_TEXTURE2D;
+                            headerDx10.miscFlag = 0u;
+                            headerDx10.arraySize = 1u;
+                            headerDx10.miscFlags2 = DDS_HEADER_DXT10.DDS_ALPHA_MODE_STRAIGHT;
+                            coder = new RGBA_ASTC_6x6_UByte();
+                        }
+                        else if (ddsArgs.Format == DdsEncodingFormat.RGBA_ASTC_8x8_UByte)
+                        {
+                            header.dwFlags |= DDS_HEADER.DDSD_LINEARSIZE;
+                            header.dwPitchOrLinearSize = GetAlignSize(bitmap);
+                            headerDx10.dxgiFormat = DXGI_FORMAT.DXGI_FORMAT_ASTC_8X8_UNORM;
+                            headerDx10.resourceDimension = D3D10_RESOURCE_DIMENSION.D3D10_RESOURCE_DIMENSION_TEXTURE2D;
+                            headerDx10.miscFlag = 0u;
+                            headerDx10.arraySize = 1u;
+                            headerDx10.miscFlags2 = DDS_HEADER_DXT10.DDS_ALPHA_MODE_STRAIGHT;
+                            coder = new RGBA_ASTC_8x8_UByte();
+                        }
                         else
                         {
                             throw new NotImplementedException();

--- a/src/Utils/Graphics/FormatProvider/Dds/DdsEncodingFormat.cs
+++ b/src/Utils/Graphics/FormatProvider/Dds/DdsEncodingFormat.cs
@@ -18,5 +18,9 @@
         RGB_ATC_UByte,
         RGBA_ATC_Explicit_UByte,
         RGBA_ATC_Interpolated_UByte,
+        RGBA_ASTC_4x4_UByte,
+        RGBA_ASTC_5x5_UByte,
+        RGBA_ASTC_6x6_UByte,
+        RGBA_ASTC_8x8_UByte,
     }
 }

--- a/src/Utils/Graphics/Texture/Coder/RGBA_ASTC_4x4_UByte.cs
+++ b/src/Utils/Graphics/Texture/Coder/RGBA_ASTC_4x4_UByte.cs
@@ -1,0 +1,45 @@
+using LibWindPop.Utils.Graphics.Bitmap;
+using LibWindPop.Utils.Graphics.Texture.IGraphicsAPITexture.DirectX;
+using LibWindPop.Utils.Graphics.Texture.IGraphicsAPITexture.OpenGLES;
+using LibWindPop.Utils.Graphics.Texture.Shared;
+using System;
+
+namespace LibWindPop.Utils.Graphics.Texture.Coder
+{
+    public readonly unsafe struct RGBA_ASTC_4x4_UByte : ITextureCoder, IPitchableTextureCoder, IDirectXTexture, IOpenGLES20CompressedTexture
+    {
+        public static DXGI_FORMAT DirectXFormat => DXGI_FORMAT.DXGI_FORMAT_ASTC_4X4_UNORM;
+
+        public static int OpenGLES20InternalFormat => 0x93B0; // GL_COMPRESSED_RGBA_ASTC_4x4_KHR
+
+        public readonly void Decode(ReadOnlySpan<byte> srcData, int width, int height, RefBitmap dstBitmap)
+        {
+            Decode(srcData, width, height, ((width + 3) / 4) * 16, dstBitmap);
+        }
+
+        public readonly void Encode(RefBitmap srcBitmap, Span<byte> dstData, int width, int height)
+        {
+            Encode(srcBitmap, dstData, width, height, ((width + 3) / 4) * 16);
+        }
+
+        public readonly void Decode(ReadOnlySpan<byte> srcData, int width, int height, int pitch, RefBitmap dstBitmap)
+        {
+            if (PVRTexLibHelper.Decode(srcData, PVRTexLib.PVRTexLibPixelFormat.ASTC_4x4, dstBitmap))
+            {
+                return;
+            }
+            ThrowHelper.ThrowWhen(width < 0 || height < 0 || pitch < 0);
+            throw new NotSupportedException("PVRTexLib is required to decode ASTC 4x4 textures.");
+        }
+
+        public readonly void Encode(RefBitmap srcBitmap, Span<byte> dstData, int width, int height, int pitch)
+        {
+            if (PVRTexLibHelper.Encode(srcBitmap, PVRTexLib.PVRTexLibPixelFormat.ASTC_4x4, dstData))
+            {
+                return;
+            }
+            ThrowHelper.ThrowWhen(width < 0 || height < 0 || pitch < 0);
+            throw new NotSupportedException("PVRTexLib is required to encode ASTC 4x4 textures.");
+        }
+    }
+}

--- a/src/Utils/Graphics/Texture/Coder/RGBA_ASTC_5x5_UByte.cs
+++ b/src/Utils/Graphics/Texture/Coder/RGBA_ASTC_5x5_UByte.cs
@@ -1,0 +1,45 @@
+using LibWindPop.Utils.Graphics.Bitmap;
+using LibWindPop.Utils.Graphics.Texture.IGraphicsAPITexture.DirectX;
+using LibWindPop.Utils.Graphics.Texture.IGraphicsAPITexture.OpenGLES;
+using LibWindPop.Utils.Graphics.Texture.Shared;
+using System;
+
+namespace LibWindPop.Utils.Graphics.Texture.Coder
+{
+    public readonly unsafe struct RGBA_ASTC_5x5_UByte : ITextureCoder, IPitchableTextureCoder, IDirectXTexture, IOpenGLES20CompressedTexture
+    {
+        public static DXGI_FORMAT DirectXFormat => DXGI_FORMAT.DXGI_FORMAT_ASTC_5X5_UNORM;
+
+        public static int OpenGLES20InternalFormat => 0x93B1; // GL_COMPRESSED_RGBA_ASTC_5x5_KHR
+
+        public readonly void Decode(ReadOnlySpan<byte> srcData, int width, int height, RefBitmap dstBitmap)
+        {
+            Decode(srcData, width, height, ((width + 4) / 5) * 16, dstBitmap);
+        }
+
+        public readonly void Encode(RefBitmap srcBitmap, Span<byte> dstData, int width, int height)
+        {
+            Encode(srcBitmap, dstData, width, height, ((width + 4) / 5) * 16);
+        }
+
+        public readonly void Decode(ReadOnlySpan<byte> srcData, int width, int height, int pitch, RefBitmap dstBitmap)
+        {
+            if (PVRTexLibHelper.Decode(srcData, PVRTexLib.PVRTexLibPixelFormat.ASTC_5x5, dstBitmap))
+            {
+                return;
+            }
+            ThrowHelper.ThrowWhen(width < 0 || height < 0 || pitch < 0);
+            throw new NotSupportedException("PVRTexLib is required to decode ASTC 5x5 textures.");
+        }
+
+        public readonly void Encode(RefBitmap srcBitmap, Span<byte> dstData, int width, int height, int pitch)
+        {
+            if (PVRTexLibHelper.Encode(srcBitmap, PVRTexLib.PVRTexLibPixelFormat.ASTC_5x5, dstData))
+            {
+                return;
+            }
+            ThrowHelper.ThrowWhen(width < 0 || height < 0 || pitch < 0);
+            throw new NotSupportedException("PVRTexLib is required to encode ASTC 5x5 textures.");
+        }
+    }
+}

--- a/src/Utils/Graphics/Texture/Coder/RGBA_ASTC_6x6_UByte.cs
+++ b/src/Utils/Graphics/Texture/Coder/RGBA_ASTC_6x6_UByte.cs
@@ -1,0 +1,45 @@
+using LibWindPop.Utils.Graphics.Bitmap;
+using LibWindPop.Utils.Graphics.Texture.IGraphicsAPITexture.DirectX;
+using LibWindPop.Utils.Graphics.Texture.IGraphicsAPITexture.OpenGLES;
+using LibWindPop.Utils.Graphics.Texture.Shared;
+using System;
+
+namespace LibWindPop.Utils.Graphics.Texture.Coder
+{
+    public readonly unsafe struct RGBA_ASTC_6x6_UByte : ITextureCoder, IPitchableTextureCoder, IDirectXTexture, IOpenGLES20CompressedTexture
+    {
+        public static DXGI_FORMAT DirectXFormat => DXGI_FORMAT.DXGI_FORMAT_ASTC_6X6_UNORM;
+
+        public static int OpenGLES20InternalFormat => 0x93B2; // GL_COMPRESSED_RGBA_ASTC_6x6_KHR
+
+        public readonly void Decode(ReadOnlySpan<byte> srcData, int width, int height, RefBitmap dstBitmap)
+        {
+            Decode(srcData, width, height, ((width + 5) / 6) * 16, dstBitmap);
+        }
+
+        public readonly void Encode(RefBitmap srcBitmap, Span<byte> dstData, int width, int height)
+        {
+            Encode(srcBitmap, dstData, width, height, ((width + 5) / 6) * 16);
+        }
+
+        public readonly void Decode(ReadOnlySpan<byte> srcData, int width, int height, int pitch, RefBitmap dstBitmap)
+        {
+            if (PVRTexLibHelper.Decode(srcData, PVRTexLib.PVRTexLibPixelFormat.ASTC_6x6, dstBitmap))
+            {
+                return;
+            }
+            ThrowHelper.ThrowWhen(width < 0 || height < 0 || pitch < 0);
+            throw new NotSupportedException("PVRTexLib is required to decode ASTC 6x6 textures.");
+        }
+
+        public readonly void Encode(RefBitmap srcBitmap, Span<byte> dstData, int width, int height, int pitch)
+        {
+            if (PVRTexLibHelper.Encode(srcBitmap, PVRTexLib.PVRTexLibPixelFormat.ASTC_6x6, dstData))
+            {
+                return;
+            }
+            ThrowHelper.ThrowWhen(width < 0 || height < 0 || pitch < 0);
+            throw new NotSupportedException("PVRTexLib is required to encode ASTC 6x6 textures.");
+        }
+    }
+}

--- a/src/Utils/Graphics/Texture/Coder/RGBA_ASTC_8x8_UByte.cs
+++ b/src/Utils/Graphics/Texture/Coder/RGBA_ASTC_8x8_UByte.cs
@@ -1,0 +1,45 @@
+using LibWindPop.Utils.Graphics.Bitmap;
+using LibWindPop.Utils.Graphics.Texture.IGraphicsAPITexture.DirectX;
+using LibWindPop.Utils.Graphics.Texture.IGraphicsAPITexture.OpenGLES;
+using LibWindPop.Utils.Graphics.Texture.Shared;
+using System;
+
+namespace LibWindPop.Utils.Graphics.Texture.Coder
+{
+    public readonly unsafe struct RGBA_ASTC_8x8_UByte : ITextureCoder, IPitchableTextureCoder, IDirectXTexture, IOpenGLES20CompressedTexture
+    {
+        public static DXGI_FORMAT DirectXFormat => DXGI_FORMAT.DXGI_FORMAT_ASTC_8X8_UNORM;
+
+        public static int OpenGLES20InternalFormat => 0x93B3; // GL_COMPRESSED_RGBA_ASTC_8x8_KHR
+
+        public readonly void Decode(ReadOnlySpan<byte> srcData, int width, int height, RefBitmap dstBitmap)
+        {
+            Decode(srcData, width, height, ((width + 7) / 8) * 16, dstBitmap);
+        }
+
+        public readonly void Encode(RefBitmap srcBitmap, Span<byte> dstData, int width, int height)
+        {
+            Encode(srcBitmap, dstData, width, height, ((width + 7) / 8) * 16);
+        }
+
+        public readonly void Decode(ReadOnlySpan<byte> srcData, int width, int height, int pitch, RefBitmap dstBitmap)
+        {
+            if (PVRTexLibHelper.Decode(srcData, PVRTexLib.PVRTexLibPixelFormat.ASTC_8x8, dstBitmap))
+            {
+                return;
+            }
+            ThrowHelper.ThrowWhen(width < 0 || height < 0 || pitch < 0);
+            throw new NotSupportedException("PVRTexLib is required to decode ASTC 8x8 textures.");
+        }
+
+        public readonly void Encode(RefBitmap srcBitmap, Span<byte> dstData, int width, int height, int pitch)
+        {
+            if (PVRTexLibHelper.Encode(srcBitmap, PVRTexLib.PVRTexLibPixelFormat.ASTC_8x8, dstData))
+            {
+                return;
+            }
+            ThrowHelper.ThrowWhen(width < 0 || height < 0 || pitch < 0);
+            throw new NotSupportedException("PVRTexLib is required to encode ASTC 8x8 textures.");
+        }
+    }
+}


### PR DESCRIPTION
## 改动内容

- 新增 `PtxHandlerPVZ2CNAndroidV6` 处理器，支持植物大战僵尸2中国版 Android V6 版本的 PTX 格式
- 新增 4 个 ASTC 纹理编码器：`RGBA_ASTC_4x4_UByte`、`RGBA_ASTC_5x5_UByte`、`RGBA_ASTC_6x6_UByte`、`RGBA_ASTC_8x8_UByte`
- 更新 DDS 编码器以支持 ASTC 格式
- 更新 PTX 相关模块以适配新增纹理格式